### PR TITLE
Must create a bin -> bin.$IRAFARCH link when none exists to begin with

### DIFF
--- a/scripts/ac_build_iraf_pkg
+++ b/scripts/ac_build_iraf_pkg
@@ -92,6 +92,8 @@ rm -fr bin.*
 mkdir bin.generic "bin.$IRAFARCH"
 if [ -L bin ]; then  # apart from being safer, there is a bin/ dir in mscdb
     rm -f bin
+fi
+if [ ! -e bin ]; then 
     ln -s "bin.$IRAFARCH" bin
 fi
 


### PR DESCRIPTION
Otherwise Gemini IRAF won't build directly from a CVS checkout, because there's no bin link in the repository.
