### PR TITLE
Use new cl script in $iraf to build package help

### DIFF
--- a/scripts/ac_build_iraf_pkg
+++ b/scripts/ac_build_iraf_pkg
@@ -133,7 +133,7 @@ if [ -r "$file_path" ]; then
     st=$?
 else
     # This is an IRAF convention that usually applies but doesn't always:
-    "$script_dir/make_iraf_help" "$pkg_name" > "$help_log_name" 2>&1
+    "$iraf/util/make_help" "$pkg_name" > "$help_log_name" 2>&1
     st=$?
 fi
 


### PR DESCRIPTION
... to simplify the build dependencies, such that IRAF & its external packages can all be built without PyRAF/Python. This was previously avoided (IIRC) due to historical experience with cl inexplicably segfaulting intermittently when trying to script the help database build, but this time we're invoking it a bit differently and it has been working reliably so far. Avoiding the PyRAF dependency allows building IRAF packages without contortions on MacOS 10.6 (the only version we have <10.10), which is no longer officially supported by Anaconda and won't run its numpy build. The new $iraf/make_help is a  compatible replacement for make_iraf_help in astroconda-iraf-helpers.